### PR TITLE
Use SRG names in transformer

### DIFF
--- a/src/main/java/com/cheeseum/pistoneverything/PistonEverythingLoadingPlugin.java
+++ b/src/main/java/com/cheeseum/pistoneverything/PistonEverythingLoadingPlugin.java
@@ -7,6 +7,7 @@ import cpw.mods.fml.relauncher.FMLInjectionData;
 import cpw.mods.fml.relauncher.IFMLLoadingPlugin;
 
 //@MCVersion(value = "1.6.4")
+@IFMLLoadingPlugin.SortingIndex(1500) // anything >1000 loads after runtime deobfuscation
 public class PistonEverythingLoadingPlugin implements IFMLLoadingPlugin {
 	
 	public static File jarLocation;
@@ -39,7 +40,6 @@ public class PistonEverythingLoadingPlugin implements IFMLLoadingPlugin {
 		
 		//XXX: initializing this here is far from ideal, but it works
 		PistonEverythingTransformerASM.obfMapper = new PistonEverythingObfuscationMapper(runtimeDeobfuscationEnabled);
-		PistonEverythingTransformerASM.obfMapper.loadMappings("/deobfuscation_data-" + FMLInjectionData.data()[4] + ".lzma");
 		PistonEverythingTransformerASM.initClassMappings();
 	}
 

--- a/src/main/java/com/cheeseum/pistoneverything/PistonEverythingObfuscationMapper.java
+++ b/src/main/java/com/cheeseum/pistoneverything/PistonEverythingObfuscationMapper.java
@@ -1,19 +1,5 @@
 package com.cheeseum.pistoneverything;
 
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import com.google.common.base.Charsets;
-import com.google.common.io.CharStreams;
-import com.google.common.io.InputSupplier;
-
-import cpw.mods.fml.common.FMLLog;
-import cpw.mods.fml.common.asm.transformers.deobf.LZMAInputSupplier;
-import cpw.mods.fml.relauncher.FMLInjectionData;
-
 public class PistonEverythingObfuscationMapper {
 	static class MethodData {
 		public MethodData(String name, String desc)
@@ -41,59 +27,11 @@ public class PistonEverythingObfuscationMapper {
 		}
 	}
 	
-	private Map<String, String> classMap;
-	private Map<String, String> fieldMap;
-	private Map<MethodData, MethodData> methodMap;
 	private boolean runtimeDeobfuscationEnabled;
 
 	public PistonEverythingObfuscationMapper (boolean enableRuntimeDeobfuscation)
 	{
-		classMap = new HashMap<String, String>();
-		fieldMap = new HashMap<String, String>();
-		methodMap = new HashMap<MethodData, MethodData>();
 		runtimeDeobfuscationEnabled = enableRuntimeDeobfuscation;
-	}
-	
-	public void loadMappings (String obfDataPath)
-	{
-        try {
-			LZMAInputSupplier zis = new LZMAInputSupplier(FMLInjectionData.class.getResourceAsStream(obfDataPath));
-	        InputSupplier<InputStreamReader> srgSupplier = CharStreams.newReaderSupplier(zis,Charsets.UTF_8);
-			List<String> srgList = CharStreams.readLines(srgSupplier);
-			
-			for (String srgMapping : srgList)
-			{
-				String[] parts = srgMapping.split(" ");
-				if (parts[0].equals("CL:"))
-				{
-					classMap.put(parts[2], parts[1]);
-				}
-				else if (parts[0].equals("FD:"))
-				{
-					String obfName = parseMapString(parts[1]);
-					String srgName = parseMapString(parts[2]);
-					
-					fieldMap.put(srgName, obfName);
-				}
-				else if (parts[0].equals("MD:"))
-				{
-					String obfName = parseMapString(parts[1]);
-					String srgName = parseMapString(parts[3]);
-					
-					methodMap.put(new MethodData(srgName, parts[4]), new MethodData(obfName, parts[2]));
-				}
-			}
-		} catch (IOException e) {
-			FMLLog.severe("An error occurred loading the deobfuscation map data: %s", e.getMessage());
-		}
-	}
-
-	public String getClassMapping (String mcpName, String srgName)
-	{
-		if (!runtimeDeobfuscationEnabled)
-			return mcpName;
-		
-		return classMap.containsKey(mcpName) ? classMap.get(mcpName) : mcpName;
 	}
 	
 	public String getFieldMapping (String mcpName, String srgName)
@@ -101,7 +39,7 @@ public class PistonEverythingObfuscationMapper {
 		if (!runtimeDeobfuscationEnabled)
 			return mcpName;
 		
-		return fieldMap.containsKey(srgName) ? fieldMap.get(srgName) : srgName;
+		return srgName;
 	}
 
 	public MethodData getMethodMapping (String mcpName, String srgName, String desc)
@@ -109,13 +47,6 @@ public class PistonEverythingObfuscationMapper {
 		if (!runtimeDeobfuscationEnabled)
 			return new MethodData(mcpName, desc);
 		
-		MethodData md = new MethodData(srgName, desc);
-		
-		return methodMap.containsKey(md) ? methodMap.get(md) : new MethodData(srgName, desc);
-	}
-	
-	private String parseMapString (String in)
-	{
-		return in.substring(in.lastIndexOf('/')+1);
+		return new MethodData(srgName, desc);
 	}
 }

--- a/src/main/java/com/cheeseum/pistoneverything/PistonEverythingTransformerASM.java
+++ b/src/main/java/com/cheeseum/pistoneverything/PistonEverythingTransformerASM.java
@@ -57,12 +57,12 @@ public class PistonEverythingTransformerASM implements IClassTransformer, Opcode
 	public static void initClassMappings()
 	{
 		c_PistonEverything = "com/cheeseum/pistoneverything/PistonEverything";
-		c_NBTTagCompound = obfMapper.getClassMapping("net/minecraft/nbt/NBTTagCompound", "NBTTagCompound");
-		c_World = obfMapper.getClassMapping("net/minecraft/world/World", "World");
-		c_TileEntity = obfMapper.getClassMapping("net/minecraft/tileentity/TileEntity", "TileEntity");
-		c_TileEntityPiston = obfMapper.getClassMapping("net/minecraft/tileentity/TileEntityPiston", "TileEntityPiston");
-		c_Block = obfMapper.getClassMapping("net/minecraft/block/Block", "Block");
-		c_RenderBlocks = obfMapper.getClassMapping("net/minecraft/client/renderer/RenderBlocks", "RenderBlocks");
+		c_NBTTagCompound = "net/minecraft/nbt/NBTTagCompound";
+		c_World = "net/minecraft/world/World";
+		c_TileEntity = "net/minecraft/tileentity/TileEntity";
+		c_TileEntityPiston = "net/minecraft/tileentity/TileEntityPiston";
+		c_Block = "net/minecraft/block/Block";
+		c_RenderBlocks = "net/minecraft/client/renderer/RenderBlocks";
 	}
 	
 	private byte[] transformTileEntityPiston(String className, byte[] in)


### PR DESCRIPTION
Since a while ago FML has let coremods set a load order priority.

Any coremods that load after the built-in deobfuscation coremod (priority 1000) get to work on the SRG-deobfuscated bytecode, instead of the fully-obfuscated bytecode.

This simplifies things a bit - no more messing around with obfuscation mappings. Of course, it's up to you whether you want this or not.